### PR TITLE
Ignore orientation accept dict

### DIFF
--- a/azint/azint.py
+++ b/azint/azint.py
@@ -48,6 +48,23 @@ class Poni:
                    float(config['rot3']),
                    float(config['wavelength']))
     
+    @classmethod
+    def from_dict(cls, config):
+        det_name = config['detector']
+        det_config = {}
+        if 'detector_config' in config:
+            det_config = json.loads(config['detector_config'])
+            if "orientation" in config['detector_config']:
+                det_config.pop("orientation", None)
+        det = Detector.factory(det_name, det_config)
+        return cls(det, 
+                   float(config['distance']), 
+                   float(config['poni1']), 
+                   float(config['poni2']), 
+                   float(config['rot1']), 
+                   float(config['rot2']),
+                   float(config['rot3']),
+                   float(config['wavelength']))
 
 def rotation_matrix(poni: Poni):
     cos_rot1 = np.cos(poni.rot1)
@@ -171,6 +188,9 @@ class AzimuthalIntegrator():
         
         if isinstance(poni, str):
             poni = Poni.from_file(poni)
+        
+        if isinstance(poni, dict):
+            poni = Poni.from_dict(poni)
         
         self.unit = unit
         self.error_model = error_model

--- a/azint/azint.py
+++ b/azint/azint.py
@@ -36,6 +36,8 @@ class Poni:
                 
         det_name = config['detector']
         det_config = json.loads(config['detector_config'])
+        if "orientation" in config['detector_config']:
+            det_config.pop("orientation", None)
         det = Detector.factory(det_name, det_config)
         return cls(det, 
                    float(config['distance']), 


### PR DESCRIPTION
In most beamlines at MAXIV, the frame orientation is currently set to "origin at the bottom left when viewed from the sample." Due to this, azint will now ignore the orientation specified in the configuration (or PONI) files.


Updated azint to disregard orientation settings from config or PONI files when using the default beamline orientation.
Enhanced azint to accept both a dictionary and a PONI file, not just a PONI file.


The new functionality allows azint to process inputs in the following way:

{
          'poni': {
              'detector': 'Eiger4M',
              'distance': '0.4010703458557646',
              'poni1': '0.15025612549194067',
              'poni2': '0.13234147820003397',
              'rot1': '-0.0006320348455512269',
              'rot2': '0.0008004131799709323',
              'rot3': '0.0',
              'wavelength': '3.542521763813852e-11'
          },
        'mask': None,
        'radial_bins': 1000,
        'azimuth_bins': None,
        'n_splitting': 4,
        'error_model': None,
        'unit': 'q',
        'polarization_factor': None
}


and also:



{
         'poni': '/path/to/poni/file',
        'mask': None,
        'radial_bins': 1000,
        'azimuth_bins': None,
        'n_splitting': 4,
        'error_model': None,
        'unit': 'q',
        'polarization_factor': None
}
